### PR TITLE
add timeout to http requests

### DIFF
--- a/src/request/request.browser.js
+++ b/src/request/request.browser.js
@@ -1,10 +1,10 @@
-export function fetch (method, url, body, headers, callback) {
+export function fetch (method, url, body, headers, callback, timeout) {
   try {
     var xhr = new XMLHttpRequest();
     xhr.onreadystatechange = function() {
       if (xhr.readyState == 4) {
         var contentType = xhr.getResponseHeader('Content-Type');
-        if (contentType.indexOf('json') !== -1) {
+        if (contentType && contentType.indexOf('json') !== -1) {
           // return JSON object
           callback(null, JSON.parse(xhr.responseText), xhr.status);
         }
@@ -22,7 +22,12 @@ export function fetch (method, url, body, headers, callback) {
       }
     }
 
+    xhr.ontimeout = function (err) {
+      callback(err, null, 0);
+    };
+
     xhr.open(method, url, true);
+    xhr.timeout = timeout;
 
     if (typeof body === 'string') {
       xhr.send(body);
@@ -40,6 +45,6 @@ export function fetch (method, url, body, headers, callback) {
   }
 }
 
-export function post (url, body, callback) {
-  fetch('POST', url, body, null, callback)
+export function post (url, body, callback, timeout) {
+  fetch('POST', url, body, null, callback, timeout)
 }

--- a/src/request/request.node.js
+++ b/src/request/request.node.js
@@ -3,7 +3,7 @@ import https from 'https';
 import url from 'url';
 var parseUrl = url.parse;
 
-export function post (url, body, callback) {
+export function post (url, body, callback, timeout) {
   var data = (body === 'string') ? body : JSON.stringify(body);
   var urlObj = parseUrl(url);
 
@@ -42,6 +42,12 @@ export function post (url, body, callback) {
   req.on('error', function(err) {
     callback && callback(err, null, null);
     callback = null;
+  });
+
+  req.on('socket', function(socket) {
+    socket.setTimeout(timeout, function() {
+      req.abort();
+    });
   });
 
   req.write(data);

--- a/src/timesync.js
+++ b/src/timesync.js
@@ -61,7 +61,7 @@ export function create(options) {
           else {
             timesync.receive(to, res);
           }
-        });
+        }, timesync.options.timeout);
       }
       catch (err) {
         emitError(err);


### PR DESCRIPTION
Fixes #11. The timeout option value is added as a timeout to HTTP requests, so that they are aborted as well as having their records deleted from timesync's _inProgress object.