### PR TITLE
Use now() from options instead of Date.now()

### DIFF
--- a/src/timesync.js
+++ b/src/timesync.js
@@ -210,11 +210,11 @@ export function create(options) {
      * @private
      */
     _getOffset: function (peer) {
-      var start = Date.now(); // local system time
+      var start = timesync.options.now(); // local system time
 
       return timesync.rpc(peer, 'timesync')
           .then(function (timestamp) {
-            var end = Date.now(); // local system time
+            var end = timesync.options.now(); // local system time
             var roundtrip = end - start;
             var offset = timestamp - end + roundtrip / 2; // offset from local system time
 


### PR DESCRIPTION
Fixes (what I think is) a bug with the `now` option by using the passed function instead of `Date.now()` in the `_getOffset` function.