### PR TITLE
Fix unhandled JSON.parse()

### DIFF
--- a/src/request/request.browser.js
+++ b/src/request/request.browser.js
@@ -5,8 +5,13 @@ export function fetch (method, url, body, headers, callback, timeout) {
       if (xhr.readyState == 4) {
         var contentType = xhr.getResponseHeader('Content-Type');
         if (contentType && contentType.indexOf('json') !== -1) {
-          // return JSON object
-          callback(null, JSON.parse(xhr.responseText), xhr.status);
+          try {
+            // return JSON object
+            var response = JSON.parse(xhr.responseText);
+            callback(null, response, xhr.status);
+          } catch (err) {
+            callback(err, null, xhr.status);
+          }
         }
         else {
           // return text

--- a/src/request/request.node.js
+++ b/src/request/request.node.js
@@ -33,9 +33,14 @@ export function post (url, body, timeout) {
       res.on('end', function () {
         var contentType = res.headers['content-type'];
         var isJSON = contentType && contentType.indexOf('json') !== -1;
-        var body = isJSON ? JSON.parse(result) : result;
 
-        resolve([body, res.statusCode]);
+        try {
+          var body = isJSON ? JSON.parse(result) : result;
+
+          resolve([body, res.statusCode]);
+        } catch (err) {
+          reject(err)
+        }
       });
     });
 


### PR DESCRIPTION
Timesync doesn't catch an error when parsing JSON response. So it ends with **unhandled error thrown** both on server and in browser.

In PR I added catch block and I reject `request.post()` promise which in turn calls `timesync.on('error')` handler.