### PR TITLE
Emit error when the HTTP StatusCode is not 200

### DIFF
--- a/src/timesync.js
+++ b/src/timesync.js
@@ -57,6 +57,10 @@ export function create(options) {
             .then(function (val) {
               var res = val[0];
 
+              if(val[1] !== 200) {
+                throw new Error(val);
+              }
+
               timesync.receive(to, res);
             })
             .catch(function (err) {


### PR DESCRIPTION
I noticed the same behaviour of this issue (https://github.com/enmasseio/timesync/issues/22).
It seems these lines are enough to fix it, at least on the master/slave configuration.
